### PR TITLE
Manage codex-app via nix-darwin's homebrew integration

### DIFF
--- a/modules/nix-darwin/configuration.nix
+++ b/modules/nix-darwin/configuration.nix
@@ -36,4 +36,18 @@
     switch-system = "nh darwin switch .";
     list-generations = "nix-env --list-generations";
   };
+
+  # Homebrew baseline. Requires brew to already be installed (nix-darwin
+  # doesn't install it — bootstrap with the install.sh from brew.sh once
+  # per machine). Casks/brews/taps are declared in the dedicated
+  # nix-darwin/homebrew module. `cleanup = "none"` leaves manually
+  # installed brews/casks alone.
+  homebrew = {
+    enable = true;
+    onActivation = {
+      autoUpdate = false;
+      upgrade = false;
+      cleanup = "none";
+    };
+  };
 }

--- a/modules/nix-darwin/default.nix
+++ b/modules/nix-darwin/default.nix
@@ -1,4 +1,5 @@
 { ... }:
 {
   default = import ./configuration.nix;
+  homebrew = import ./homebrew;
 }

--- a/modules/nix-darwin/homebrew/default.nix
+++ b/modules/nix-darwin/homebrew/default.nix
@@ -1,0 +1,10 @@
+{ ... }:
+{
+  # Brew-managed apps — proprietary macOS GUIs that aren't packaged in
+  # nixpkgs. Requires the base homebrew block in
+  # modules/nix-darwin/configuration.nix to enable Homebrew itself.
+  homebrew.casks = [
+    # OpenAI's Codex desktop app — ships as a .dmg, not in nixpkgs.
+    "codex-app"
+  ];
+}

--- a/systems/STOLTM7XVQCG7/default.nix
+++ b/systems/STOLTM7XVQCG7/default.nix
@@ -5,6 +5,7 @@ nix-darwin.lib.darwinSystem {
   modules = [
     ./configuration.nix
     self.darwinModules.default
+    self.darwinModules.homebrew
     self.modules.default
   ];
 }


### PR DESCRIPTION
## Summary
- Adds a homebrew baseline (`enable` + `onActivation`) to `modules/nix-darwin/configuration.nix`. Requires brew to be installed on the host — nix-darwin doesn't install it.
- New `modules/nix-darwin/homebrew/` submodule holds the cask list. First entry: OpenAI's Codex desktop app (\`codex-app\`), which ships as a .dmg and isn't in nixpkgs. Future brew-managed apps go in the same file.
- Wires the new module into the work host (\`systems/STOLTM7XVQCG7\`).

## Test plan
- [x] \`nix flake check\` and \`nix flake check --all-systems\` pass locally
- [x] \`switch-system\` activates the new generation and \`brew bundle\` installs Codex.app to /Applications

🤖 Generated with [Claude Code](https://claude.com/claude-code)