### PR TITLE
Add llama-cpp to home.packages

### DIFF
--- a/modules/home-manager/home/default.nix
+++ b/modules/home-manager/home/default.nix
@@ -132,6 +132,7 @@
     kubectx
     kubernetes-helm
     lame
+    llama-cpp
     lynis
     maple-mono.variable
     mdcat


### PR DESCRIPTION
## What

Adds the `llama-cpp` inference runtime to the shared home-manager package list (`modules/home-manager/home/default.nix`).

## Details

- Sourced from the pinned `nixpkgs` (26.05 stable) — `llama-cpp-9190`. No new flake input required.
- Provides `llama-cli`, `llama-server`, etc. on PATH.
- On Darwin this builds with Metal acceleration by default.
- Placed in `home.packages` rather than the `llm` module, since that module is scoped to agent-CLI `programs.*` config from the `llm-agents` flake and has no package list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)