### PR TITLE
Import macos-spotlight-apps in the john home

### DIFF
--- a/homes/john/default.nix
+++ b/homes/john/default.nix
@@ -24,6 +24,7 @@ home-manager.lib.homeManagerConfiguration {
     self.homeModules.home
     self.homeModules.kitty
     self.homeModules.llm
+    self.homeModules.macos-spotlight-apps
     self.homeModules.tmux
     self.homeModules.vim
     self.homeModules.vscode


### PR DESCRIPTION
## Problem

The `aarch64-darwin` per-system module sets `services.macos-spotlight-apps.enable = true`, but that option is **declared** in a separate `macos-spotlight-apps` module that each home imports explicitly.

The `john` home imports the Darwin per-system module (automatically, by building on Apple Silicon) but did **not** import `macos-spotlight-apps`. Result: it failed to evaluate with

```
error: The option `services.macos-spotlight-apps' does not exist.
```

## Fix

Import `macos-spotlight-apps` in the `john` home — matching the pattern every other home (and the upstream `carl`/`carlthome` homes) already follows. Minimal, low-risk, consistent with the existing convention.

A structural follow-up (bundling the module into the `aarch64-darwin` per-system module so no home can forget it) rides along with the module-restructuring PR.

## Verification

Both `homeConfigurations.john` and `homeConfigurations."john.pertoft"` now evaluate; `services.macos-spotlight-apps.enable` resolves to `true` for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)