### PR TITLE
Migrate Chrome, Obsidian, just, node, ccache from brew/dmg to nix

### DIFF
--- a/modules/home-manager/aarch64-darwin/default.nix
+++ b/modules/home-manager/aarch64-darwin/default.nix
@@ -13,6 +13,8 @@
       pkg:
       builtins.elem (lib.getName pkg) [
         "claude-code"
+        "google-chrome"
+        "obsidian"
         "terraform"
         "vscode"
       ];
@@ -20,9 +22,11 @@
 
   home.packages = with pkgs; [
     colima
-    net-news-wire
-    stats
+    google-chrome
     iterm2
+    net-news-wire
+    obsidian
+    stats
   ];
 
   # Use the Apple-patched system ssh so options like UseKeychain in

--- a/modules/home-manager/development/build/default.nix
+++ b/modules/home-manager/development/build/default.nix
@@ -4,6 +4,7 @@
 {
   # Native-build prerequisites used across C/C++ and other compiled tooling.
   home.packages = with pkgs; [
+    ccache
     cmake
     gcc
     gnumake

--- a/modules/home-manager/development/node/default.nix
+++ b/modules/home-manager/development/node/default.nix
@@ -3,8 +3,8 @@
 }:
 {
   home.packages = with pkgs; [
+    nodejs
     yarn
-    #nodejs
     #nodePackages.npm
     #nodePackages.prettier
   ];

--- a/modules/home-manager/development/tools/default.nix
+++ b/modules/home-manager/development/tools/default.nix
@@ -8,5 +8,6 @@
     act
     asdf-vm
     ctags
+    just
   ];
 }


### PR DESCRIPTION
Bring six manually-installed programs under home-manager:
- google-chrome, obsidian: darwin GUI apps (+ unfree allow-list entries)
- nodejs: uncomment in development/node
- ccache: development/build
- just: development/tools

Verified the john.pertoft home activation package builds.