### PR TITLE
feat/tailscale

### DIFF
--- a/systems/STOLTM7XVQCG7/configuration.nix
+++ b/systems/STOLTM7XVQCG7/configuration.nix
@@ -4,6 +4,11 @@
 
   system.primaryUser = "john.pertoft";
 
+  # Tailscale client — reach the homelab (the Pi's Tailscale-only services)
+  # over the tailnet. This is the tailscaled daemon (CLI, not the menu-bar
+  # app); run `sudo tailscale up` once to authenticate.
+  services.tailscale.enable = true;
+
   # Required. Increment when nix-darwin release notes say so.
   system.stateVersion = 6;
 }

--- a/systems/home-desktop/configuration.nix
+++ b/systems/home-desktop/configuration.nix
@@ -54,6 +54,10 @@
     };
   };
 
+  # Tailscale client — reach the homelab (the Pi's Tailscale-only services)
+  # over the tailnet. Run `sudo tailscale up` once to authenticate.
+  services.tailscale.enable = true;
+
   # Enable cross-platform emulator for building aarch64-linux (e.g. pi) locally.
   boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
 


### PR DESCRIPTION
Enable services.tailscale on both hosts so they can reach the homelab (the Pi's Tailscale-only services) over the tailnet. Client-only — no routing/exit-node features. Authenticate once per host with `sudo tailscale up`.