### PR TITLE
Add Mealie recipe manager & meal planner to the Pi

### DIFF
--- a/systems/pi/services/default.nix
+++ b/systems/pi/services/default.nix
@@ -15,6 +15,7 @@
     ./home-assistant
     ./jellyfin
     ./transmission
+    ./mealie
     ./www
   ];
 }

--- a/systems/pi/services/mealie/default.nix
+++ b/systems/pi/services/mealie/default.nix
@@ -1,0 +1,39 @@
+{ ... }:
+
+{
+  # Mealie — self-hosted recipe manager & meal planner, on http://pi.local:9000
+  # (LAN) and http://pi:9000 (tailnet). Runs as a native systemd service via the
+  # NixOS module: the package is cached for aarch64, so there's no from-source
+  # build on the Pi (unlike the container-only services). State (SQLite DB,
+  # uploaded recipe images, backups) lives in the module's StateDirectory,
+  # /var/lib/mealie, on the T7 SSD — so it survives reboots. SQLite is the
+  # default backend; fine for a single household and avoids running a Postgres
+  # process on the 4 GB box (flip database.createLocally if that ever changes).
+  services.mealie = {
+    enable = true;
+    port = 9000;
+
+    # settings become the container/app's environment variables.
+    settings = {
+      # Timezone drives the meal-plan calendar and recipe timestamps. The Pi
+      # otherwise has no time.timeZone set (defaults to UTC).
+      TZ = "Europe/Stockholm";
+
+      # No open self-registration: the app is on the LAN, so keep account
+      # creation admin-only. On first login use the default admin account
+      # (changeme@example.com / MyPassword) and immediately change both.
+      ALLOW_SIGNUP = "false";
+
+      # Only affects generated share links / invite URLs, not where the app
+      # binds. Pointed at the LAN name; tailnet access still works, its share
+      # links just won't be clickable off-LAN (cosmetic).
+      BASE_URL = "http://pi.local:9000";
+    };
+  };
+
+  # LAN-exposed like Grafana/Jellyfin so recipes are reachable from a phone in
+  # the kitchen without Tailscale. tailscale0 is already a trusted interface,
+  # so this also covers tailnet access. Not internet-exposed (no router
+  # port-forward to the Pi).
+  networking.firewall.allowedTCPPorts = [ 9000 ];
+}

--- a/systems/pi/services/www/default.nix
+++ b/systems/pi/services/www/default.nix
@@ -59,6 +59,7 @@ let
           { name: "Grafana", port: 3000, note: "metrics & logs" },
           { name: "Jellyfin", port: 8096, note: "media" },
           { name: "Home Assistant", port: 8123, note: "home automation" },
+          { name: "Mealie", port: 9000, note: "recipes & meal planning" },
           { name: "Transmission", port: 9091, note: "downloads · Tailscale only" }
         ];
         var ul = document.getElementById("services");


### PR DESCRIPTION
Adds [Mealie](https://mealie.io) — a self-hosted recipe manager & meal planner — to the Raspberry Pi service stack.

## What
- New `systems/pi/services/mealie/default.nix` using the native `services.mealie` module.
- Wired into `services/default.nix` and linked from the `www` landing page.

## Choices
- **Native module, not a container.** The `mealie` package is cached for aarch64 (2.1 MB download), so there's no from-source build/OOM risk on the 4 GB Pi — unlike the container-only services.
- **SQLite** (module default): no extra Postgres process; plenty for a single household. State in `/var/lib/mealie` on the T7 SSD, survives reboots.
- **LAN + Tailscale** on `:9000` (`listenAddress` `0.0.0.0` + firewall port), like Grafana/Jellyfin — reachable from a phone in the kitchen. Not internet-exposed (no router port-forward).
- `ALLOW_SIGNUP=false` (LAN-exposed; change the default admin `changeme@example.com` / `MyPassword` on first login), `TZ=Europe/Stockholm`.

## Validation
- `nix eval` on the Pi toplevel builds the closure drv cleanly.
- `nixpkgs-fmt --check` passes; pre-commit hooks green.
- Not yet deployed — the Pi reconciles to `main` and rebuilds after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)