### PR TITLE
Swap llm-agents binary cache to cache.numtide.com

### DIFF
--- a/modules/configuration.nix
+++ b/modules/configuration.nix
@@ -8,12 +8,14 @@
     ];
     substituters = [
       "https://nix-community.cachix.org"
-      "https://numtide.cachix.org"
+      # llm-agents.nix's prebuilt binaries (codex, claude-code, gemini-cli, …).
+      # Replaces the old numtide.cachix.org cache, which it migrated away from.
+      "https://cache.numtide.com"
       "https://devenv.cachix.org"
     ];
     trusted-public-keys = [
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-      "numtide.cachix.org-1:2ps1kLBUWjxIneOy1Ik6cQjb41X0iXVXeHigGmycPPE="
+      "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
       "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw="
     ];
     cores = 0;


### PR DESCRIPTION
## What

`llm-agents.nix` migrated its binary cache from `numtide.cachix.org` to `https://cache.numtide.com` (key `niks3.numtide.com-1:…`). Our config still only listed the old cachix cache, so the agent CLIs (codex, claude-code, gemini-cli, …) were **compiling from source** on every `home switch` instead of being substituted.

## Change
- Add `https://cache.numtide.com` + its trusted public key to `nix.settings` in `modules/configuration.nix`.
- Drop the now-dead `numtide.cachix.org` substituter + key.

## Why dropping the old one is safe
- `numtide.cachix.org` was added (Nov 2025) when the only numtide input was `flake-utils` — a pure library flake with no binary artifacts to cache.
- The one real consumer, `llm-agents`, has moved to the new cache.
- A scan of the current system closure (120 sampled paths of 1656) found **0** paths served by `numtide.cachix.org`. Anything it could serve is already covered by `cache.nixos.org`.

## Verification
- Confirmed `cache.numtide.com` serves the exact store paths this flake builds — e.g. `codex-0.145.0` for aarch64-darwin, aarch64-linux, and x86_64-linux (plus claude-code / gemini-cli) all return valid narinfo.
- `nix eval` of the darwin config resolves the expected substituter + key lists after the swap.

Takes effect on the next `nh home switch` / `darwin-rebuild`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)