### PR TITLE
Make fish selectable as the login shell on darwin

### DIFF
--- a/modules/home-manager/home/default.nix
+++ b/modules/home-manager/home/default.nix
@@ -10,8 +10,6 @@
   home.sessionVariables = {
     EDITOR = "${config.home.homeDirectory}/.nix-profile/bin/vim";
     VISUAL = "${config.home.homeDirectory}/.nix-profile/bin/code";
-    #TODO This screws up SSH on macOS.
-    #SHELL = "fish";
   };
 
   # Register shell aliases.

--- a/modules/nix-darwin/configuration.nix
+++ b/modules/nix-darwin/configuration.nix
@@ -10,6 +10,22 @@
     enableSyntaxHighlighting = true;
   };
 
+  # Needed in addition to home-manager's `programs.fish.enable`: that one only
+  # writes ~/.config/fish, while this puts fish in the *system* profile so
+  # /run/current-system/sw/bin/fish exists — which is the path environment.shells
+  # below points at.
+  programs.fish.enable = true;
+
+  # Add fish to /etc/shells so `chsh` accepts it. The seven default macOS
+  # shells are preserved automatically by nix-darwin, so this only appends.
+  #
+  # Selecting the login shell stays manual, once per machine:
+  #   chsh -s /run/current-system/sw/bin/fish
+  # The declarative users.users.<name>.shell isn't used because its activation
+  # is gated on users.knownUsers, and that option is documented as being for
+  # accounts nix-darwin may freely create and delete.
+  environment.shells = with pkgs; [ fish ];
+
   # System packages — most user-facing tools live in home-manager.
   environment.systemPackages = with pkgs; [
     clang


### PR DESCRIPTION
## Problem

`programs.fish.enable` in home-manager writes `~/.config/fish` but never touches the account's login shell, so the work laptop kept starting zsh (`dscl . -read /Users/<user> UserShell` → `/bin/zsh`). The fish-as-default wiring only existed on the NixOS side (`users.defaultUserShell`, `environment.shells`), with no darwin equivalent — `modules/nix-darwin/configuration.nix` set up `programs.zsh` and stopped there.

## Change

Two coupled additions to the darwin module — `environment.shells` alone would write a dangling path into `/etc/shells`:

- **`programs.fish.enable`** puts fish in the *system* profile so `/run/current-system/sw/bin/fish` exists. The home-manager module installs into `~/.nix-profile`, which `environment.shells` can't reference. nix-darwin also asserts this is set whenever a user has a fish shell (`modules/users/default.nix:123`).
- **`environment.shells`** appends that path to `/etc/shells` so `chsh` accepts it. The seven stock macOS entries are preserved automatically.

Also drops the commented-out `SHELL = "fish"` and its TODO from the home module. That variable is only an advertisement other programs read, so it could never have changed the login shell — which is why it broke ssh instead.

## Verification

- `nix eval` of `config.assertions`: **0 of 169 failing** — covers the `programs.fish.enable` assertion that would have fired had only `environment.shells` been added
- `fish-4.7.1` present in `config.environment.systemPackages`
- resulting `/etc/shells` keeps all seven stock entries and appends `/run/current-system/sw/bin/fish`
- current `/etc/shells` hashes to nix-darwin's known-stock value, so activation takes the file over without aborting
- `nixpkgs-fmt --check` clean; pre-commit hooks passed

## Deploying

Order matters — `chsh` fails before activation, since the target path doesn't exist yet:

```
switch-system
ls -la /run/current-system/sw/bin/fish
chsh -s /run/current-system/sw/bin/fish
```

## Note on the remaining manual step

Setting the login shell stays a per-machine `chsh`. `users.users.<name>.shell` would be declarative, but its activation script is gated on `mkIf (cfg.knownUsers != [])` and only touches users listed there — so it's a silent no-op unless the account is added to `users.knownUsers`, which that option documents as being for accounts nix-darwin may freely create and delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)