### PR TITLE
feat(llm): manage claude-code settings.json via Nix with mutable merge

### DIFF
--- a/homes/john.pertoft/llm.nix
+++ b/homes/john.pertoft/llm.nix
@@ -1,13 +1,48 @@
 { pkgs
 , lib
+, config
 , ...
 }:
 let
   # Same auto-discovery pattern as modules/home-manager/llm. Skills here
   # merge with the shared ones via attrset merging in nix's module system.
-  discoverSkills = dir:
-    lib.mapAttrs (name: _: dir + "/${name}")
-      (lib.filterAttrs (_: v: v == "directory") (builtins.readDir dir));
+  discoverSkills =
+    dir:
+    lib.mapAttrs (name: _: dir + "/${name}") (
+      lib.filterAttrs (_: v: v == "directory") (builtins.readDir dir)
+    );
+
+  # Claude Code settings managed by Nix. On each switch these are deep-merged
+  # into ~/.claude/settings.json using jq's recursive * operator — Nix values
+  # win on conflicts; keys absent from Nix survive untouched.
+  #
+  # Deliberately excluded (written by Claude Code's own /theme and /plugin
+  # UI commands — putting them here would silently revert user changes on
+  # every switch):
+  #   theme, enabledPlugins
+  claudeSettings = {
+    permissions.defaultMode = "auto";
+    skipAutoPermissionPrompt = true;
+    autoUpdatesChannel = "stable";
+    voice = {
+      enabled = true;
+      mode = "hold";
+    };
+    extraKnownMarketplaces = {
+      ai-engineering-marketplace = {
+        source = {
+          source = "git";
+          url = "git@github.int.midasplayer.com:ai-ml/ai-engineering-marketplace.git";
+        };
+      };
+    };
+    statusLine = {
+      type = "command";
+      command = ''input=$(cat); dir=$(echo "$input" | jq -r '.workspace.current_dir'); display="''${dir/$HOME/~}"; display=$(echo "$display" | awk -F'/' '{parts=0; for(i=1;i<=NF;i++) if($i!="") parts++; if(parts>3){p=""; c=0; for(i=NF;i>=1;i--) if($i!=""){p="/"$i p; if(++c==3)break}; print "..."p} else print $0}'); branch=$(git --no-optional-locks -C "$dir" symbolic-ref --short HEAD 2>/dev/null); dirty=""; git --no-optional-locks -C "$dir" status --porcelain 2>/dev/null | grep -q . && dirty="!"; model=$(echo "$input" | jq -r '.model.display_name'); used=$(echo "$input" | jq -r '.context_window.used_percentage // empty'); printf "\033[1;36m[%s]\033[0m " "$display"; [ -n "$branch" ] && printf "\033[1;35m[%s%s]\033[0m " "$branch" "$dirty"; printf "\033[1;37m[%s]\033[0m " "$model"; [ -n "$used" ] && printf "\033[1;33m[ctx:%.0f%%]\033[0m" "$used"'';
+    };
+  };
+
+  claudeSettingsFile = pkgs.writeText "claude-settings-base.json" (builtins.toJSON claudeSettings);
 
   # TODO: re-enable once CI can evaluate this without a VPN. The
   # internal King marketplace lives behind github.int.midasplayer.com,
@@ -36,4 +71,22 @@ in
     #   "${ai-engineering-marketplace}/plugins/git-worktree-create"
     # ];
   };
+
+  # Merge Nix-managed settings into ~/.claude/settings.json on each switch.
+  # jq's recursive * operator is used with Nix as the right operand so Nix
+  # wins on key conflicts; keys only present in the live file survive untouched.
+  # Arrays and scalars are replaced wholesale (not appended) when Nix defines them.
+  home.activation.mergeClaudeSettings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    settings="${config.home.homeDirectory}/.claude/settings.json"
+
+    if [ -f "$settings" ] && [ ! -L "$settings" ]; then
+      tmp="$settings.tmp"
+      ${lib.getExe pkgs.jq} -s '.[1] * .[0]' "${claudeSettingsFile}" "$settings" > "$tmp" \
+        && $DRY_RUN_CMD mv "$tmp" "$settings" \
+        || rm -f "$tmp"
+    else
+      $DRY_RUN_CMD rm -f "$settings"
+      $DRY_RUN_CMD install -Dm 644 "${claudeSettingsFile}" "$settings"
+    fi
+  '';
 }

--- a/homes/john.pertoft/llm.nix
+++ b/homes/john.pertoft/llm.nix
@@ -1,6 +1,5 @@
 { pkgs
 , lib
-, config
 , ...
 }:
 let
@@ -11,38 +10,6 @@ let
     lib.mapAttrs (name: _: dir + "/${name}") (
       lib.filterAttrs (_: v: v == "directory") (builtins.readDir dir)
     );
-
-  # Claude Code settings managed by Nix. On each switch these are deep-merged
-  # into ~/.claude/settings.json using jq's recursive * operator — Nix values
-  # win on conflicts; keys absent from Nix survive untouched.
-  #
-  # Deliberately excluded (written by Claude Code's own /theme and /plugin
-  # UI commands — putting them here would silently revert user changes on
-  # every switch):
-  #   theme, enabledPlugins
-  claudeSettings = {
-    permissions.defaultMode = "auto";
-    skipAutoPermissionPrompt = true;
-    autoUpdatesChannel = "stable";
-    voice = {
-      enabled = true;
-      mode = "hold";
-    };
-    extraKnownMarketplaces = {
-      ai-engineering-marketplace = {
-        source = {
-          source = "git";
-          url = "git@github.int.midasplayer.com:ai-ml/ai-engineering-marketplace.git";
-        };
-      };
-    };
-    statusLine = {
-      type = "command";
-      command = ''input=$(cat); dir=$(echo "$input" | jq -r '.workspace.current_dir'); display="''${dir/$HOME/~}"; display=$(echo "$display" | awk -F'/' '{parts=0; for(i=1;i<=NF;i++) if($i!="") parts++; if(parts>3){p=""; c=0; for(i=NF;i>=1;i--) if($i!=""){p="/"$i p; if(++c==3)break}; print "..."p} else print $0}'); branch=$(git --no-optional-locks -C "$dir" symbolic-ref --short HEAD 2>/dev/null); dirty=""; git --no-optional-locks -C "$dir" status --porcelain 2>/dev/null | grep -q . && dirty="!"; model=$(echo "$input" | jq -r '.model.display_name'); used=$(echo "$input" | jq -r '.context_window.used_percentage // empty'); printf "\033[1;36m[%s]\033[0m " "$display"; [ -n "$branch" ] && printf "\033[1;35m[%s%s]\033[0m " "$branch" "$dirty"; printf "\033[1;37m[%s]\033[0m " "$model"; [ -n "$used" ] && printf "\033[1;33m[ctx:%.0f%%]\033[0m" "$used"'';
-    };
-  };
-
-  claudeSettingsFile = pkgs.writeText "claude-settings-base.json" (builtins.toJSON claudeSettings);
 
   # TODO: re-enable once CI can evaluate this without a VPN. The
   # internal King marketplace lives behind github.int.midasplayer.com,
@@ -72,21 +39,15 @@ in
     # ];
   };
 
-  # Merge Nix-managed settings into ~/.claude/settings.json on each switch.
-  # jq's recursive * operator is used with Nix as the right operand so Nix
-  # wins on key conflicts; keys only present in the live file survive untouched.
-  # Arrays and scalars are replaced wholesale (not appended) when Nix defines them.
-  home.activation.mergeClaudeSettings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    settings="${config.home.homeDirectory}/.claude/settings.json"
-
-    if [ -f "$settings" ] && [ ! -L "$settings" ]; then
-      tmp="$settings.tmp"
-      ${lib.getExe pkgs.jq} -s '.[1] * .[0]' "${claudeSettingsFile}" "$settings" > "$tmp" \
-        && $DRY_RUN_CMD mv "$tmp" "$settings" \
-        || rm -f "$tmp"
-    else
-      $DRY_RUN_CMD rm -f "$settings"
-      $DRY_RUN_CMD install -Dm 644 "${claudeSettingsFile}" "$settings"
-    fi
-  '';
+  # Work-specific Claude Code settings merged on top of the shared settings
+  # defined in modules/home-manager/llm. The shared module's activation script
+  # picks these up at eval time via config.programs.claude-code.extraSettings.
+  programs.claude-code.extraSettings.extraKnownMarketplaces = {
+    ai-engineering-marketplace = {
+      source = {
+        source = "git";
+        url = "git@github.int.midasplayer.com:ai-ml/ai-engineering-marketplace.git";
+      };
+    };
+  };
 }

--- a/modules/home-manager/llm/default.nix
+++ b/modules/home-manager/llm/default.nix
@@ -66,8 +66,8 @@ let
   ' '';
 
   # yq-based merge for TOML config files.
-  # `.` = nix (first arg), `input` = live (second arg); right side (*) wins.
-  yqTomlMerge = "${lib.getExe pkgs.yq-go} eval-all --input-format=toml --output-format=toml 'input * .'";
+  # fi==0 = nix (first arg), fi==1 = live (second arg); right side (*) wins.
+  yqTomlMerge = "${lib.getExe pkgs.yq-go} ea --input-format=toml --output-format=toml 'select(fi==1) * select(fi==0)'";
 
   # Claude Code: merge shared settings + host-specific extraSettings into one JSON.
   claudeNixSettings =

--- a/modules/home-manager/llm/default.nix
+++ b/modules/home-manager/llm/default.nix
@@ -167,7 +167,7 @@ in
 
       enableMcpIntegration = true;
 
-      settings.approval_policy = "never";
+      settings.approval_policy = "on-request";
     };
 
     # gemini-cli was renamed upstream to antigravity-cli (Google rebrand).

--- a/modules/home-manager/llm/default.nix
+++ b/modules/home-manager/llm/default.nix
@@ -19,10 +19,58 @@ let
     lib.mapAttrs (name: _: dir + "/${name}")
       (lib.filterAttrs (_: v: v == "directory") (builtins.readDir dir));
 
-  # Merge shared Nix settings with any host-specific extras contributed via
-  # myDotfiles.claudeSettingsExtra, then generate a store-path JSON for the
-  # activation script to merge into the live ~/.claude/settings.json.
-  nixSettingsFile =
+  # Returns a home.activation DAG entry that merges a Nix settings store-path
+  # into a mutable live config file on each switch. Nix wins on conflicts;
+  # keys absent from Nix survive untouched (e.g. theme, enabledPlugins).
+  #
+  # mergeCmd and diffCmd are shell snippets called as: cmd <nix-file> <live-file>
+  # In both, the right-hand side (nix) wins on conflicts.
+  mkMutableMerge =
+    { label       # shown in the diff header, e.g. "claude settings.json"
+    , nixFile     # store-path derivation of the Nix-managed settings
+    , liveFile    # absolute path string to the live mutable config file
+    , mergeCmd    # shell snippet: produces merged output on stdout
+    , diffCmd ? null  # shell snippet: produces overwrite report on stdout
+    }:
+    lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      nix_src="${nixFile}"
+      live="${liveFile}"
+
+      if [ -f "$live" ] && [ ! -L "$live" ]; then
+        ${lib.optionalString (diffCmd != null) ''
+          overwritten=$(${diffCmd} "$nix_src" "$live")
+          if [ -n "$overwritten" ]; then
+            echo "${label}: Nix overwrote:"
+            echo "$overwritten"
+          fi
+        ''}
+        tmp="$live.tmp"
+        ${mergeCmd} "$nix_src" "$live" > "$tmp" \
+          && $DRY_RUN_CMD mv "$tmp" "$live" \
+          || rm -f "$tmp"
+      else
+        $DRY_RUN_CMD rm -f "$live"
+        $DRY_RUN_CMD install -Dm 644 "$nix_src" "$live"
+      fi
+    '';
+
+  # jq-based merge and diff for JSON config files.
+  # .[0] = nix (first arg), .[1] = live (second arg); right side wins in jq.
+  jqMerge = "${lib.getExe pkgs.jq} -s '.[1] * .[0]'";
+  jqDiff = ''${lib.getExe pkgs.jq} -sr '
+    .[0] as $nix | .[1] as $live |
+    [ $nix | to_entries[] |
+      select($live[.key] != null and ($live[.key] | tojson) != (.value | tojson)) |
+      "~ \(.key)\n-  \($live[.key] | tojson)\n+  \(.value | tojson)"
+    ] | .[]
+  ' '';
+
+  # yq-based merge for TOML config files.
+  # `.` = nix (first arg), `input` = live (second arg); right side (*) wins.
+  yqTomlMerge = "${lib.getExe pkgs.yq-go} eval-all --input-format=toml --output-format=toml 'input * .'";
+
+  # Claude Code: merge shared settings + host-specific extraSettings into one JSON.
+  claudeNixSettings =
     (pkgs.formats.json { }).generate "claude-settings.json"
       (lib.recursiveUpdate config.programs.claude-code.settings
         config.programs.claude-code.extraSettings);
@@ -113,50 +161,13 @@ in
       skills = discoverSkills ./skills;
     };
 
-    # Suppress the read-only symlink that programs.claude-code.settings would
-    # normally generate — the activation script below writes a mutable copy
-    # instead, so Claude Code can write back to it (e.g. /theme, permissions).
-    home.file."${config.programs.claude-code.configDir}/settings.json".enable =
-      lib.mkForce false;
-
-    # Merge Nix-managed settings into ~/.claude/settings.json on each switch.
-    # nixSettingsFile is the combined shared + host-specific settings baked
-    # into the store at eval time. jq's recursive * operator applies it with
-    # Nix as the right operand — Nix wins on conflicts, keys absent from Nix
-    # (e.g. theme) survive untouched. Arrays/scalars are replaced wholesale.
-    home.activation.mergeClaudeSettings =
-      lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-        settings="${config.home.homeDirectory}/.claude/settings.json"
-
-        if [ -f "$settings" ] && [ ! -L "$settings" ]; then
-          overwritten=$(${lib.getExe pkgs.jq} -sr '
-            .[0] as $nix | .[1] as $live |
-            [ $nix | to_entries[] |
-              select($live[.key] != null and ($live[.key] | tojson) != (.value | tojson)) |
-              "~ \(.key)\n-  \($live[.key] | tojson)\n+  \(.value | tojson)"
-            ] | .[]
-          ' "${nixSettingsFile}" "$settings")
-
-          if [ -n "$overwritten" ]; then
-            echo "claude settings.json: Nix overwrote:"
-            echo "$overwritten"
-          fi
-
-          tmp="$settings.tmp"
-          ${lib.getExe pkgs.jq} -s '.[1] * .[0]' "${nixSettingsFile}" "$settings" > "$tmp" \
-            && $DRY_RUN_CMD mv "$tmp" "$settings" \
-            || rm -f "$tmp"
-        else
-          $DRY_RUN_CMD rm -f "$settings"
-          $DRY_RUN_CMD install -Dm 644 "${nixSettingsFile}" "$settings"
-        fi
-      '';
-
     programs.codex = {
       enable = true;
       package = agents.codex;
 
       enableMcpIntegration = true;
+
+      settings.approval_policy = "auto";
     };
 
     # gemini-cli was renamed upstream to antigravity-cli (Google rebrand).
@@ -165,6 +176,29 @@ in
       package = agents.antigravity-cli;
 
       enableMcpIntegration = true;
+    };
+
+    # Suppress the read-only symlinks that the upstream modules would generate
+    # from settings/MCP integration — the activation scripts below write
+    # mutable copies instead, so tools can still write back to their configs.
+    home.file."${config.programs.claude-code.configDir}/settings.json".enable =
+      lib.mkForce false;
+    home.file.".codex/config.toml".enable =
+      lib.mkForce false;
+
+    home.activation.mergeClaudeSettings = mkMutableMerge {
+      label = "claude settings.json";
+      nixFile = claudeNixSettings;
+      liveFile = "${config.home.homeDirectory}/.claude/settings.json";
+      mergeCmd = jqMerge;
+      diffCmd = jqDiff;
+    };
+
+    home.activation.mergeCodexConfig = mkMutableMerge {
+      label = "codex config.toml";
+      nixFile = config.home.file.".codex/config.toml".source;
+      liveFile = "${config.home.homeDirectory}/.codex/config.toml";
+      mergeCmd = yqTomlMerge;
     };
   };
 }

--- a/modules/home-manager/llm/default.nix
+++ b/modules/home-manager/llm/default.nix
@@ -167,7 +167,7 @@ in
 
       enableMcpIntegration = true;
 
-      settings.approval_policy = "auto";
+      settings.approval_policy = "never";
     };
 
     # gemini-cli was renamed upstream to antigravity-cli (Google rebrand).

--- a/modules/home-manager/llm/default.nix
+++ b/modules/home-manager/llm/default.nix
@@ -1,5 +1,6 @@
 { pkgs
 , lib
+, config
 , llm-agents
 , self
 , ...
@@ -17,72 +18,153 @@ let
   discoverSkills = dir:
     lib.mapAttrs (name: _: dir + "/${name}")
       (lib.filterAttrs (_: v: v == "directory") (builtins.readDir dir));
+
+  # Merge shared Nix settings with any host-specific extras contributed via
+  # myDotfiles.claudeSettingsExtra, then generate a store-path JSON for the
+  # activation script to merge into the live ~/.claude/settings.json.
+  nixSettingsFile =
+    (pkgs.formats.json { }).generate "claude-settings.json"
+      (lib.recursiveUpdate config.programs.claude-code.settings
+        config.programs.claude-code.extraSettings);
 in
 {
-  home.packages = [
-    # Local inference runtime (llama-cli, llama-server, ...). From nixpkgs
-    # rather than the llm-agents flake, which only ships agent CLIs.
-    pkgs.llama-cpp
+  options.programs.claude-code.extraSettings = lib.mkOption {
+    type = lib.types.attrsOf lib.types.anything;
+    default = { };
+    description = ''
+      Host-specific Claude Code settings merged on top of the shared
+      programs.claude-code.settings during activation. Use this for settings
+      that should not apply to every host (e.g. work-specific marketplaces).
+    '';
+  };
 
-    # pi (earendil-works/pi): terminal coding agent with multi-model
-    # support. Installed as a bare package — unlike claude-code/codex/
-    # antigravity-cli below, home-manager 26.05 ships no `programs.pi`
-    # module, so it can't opt into the shared MCP servers via
-    # enableMcpIntegration. Configure MCP for it manually if needed.
-    agents.pi
+  config = {
+    home.packages = [
+      # Local inference runtime (llama-cli, llama-server, ...). From nixpkgs
+      # rather than the llm-agents flake, which only ships agent CLIs.
+      pkgs.llama-cpp
 
-    # ai: one-shot terminal prompt wrapping `claude -p` (reuses its login,
-    # MCP off, terse output). Lives here alongside the agent CLIs it shells out to.
-    self.packages.${pkgs.stdenv.hostPlatform.system}.ai
-  ];
+      # pi (earendil-works/pi): terminal coding agent with multi-model
+      # support. Installed as a bare package — unlike claude-code/codex/
+      # antigravity-cli below, home-manager 26.05 ships no `programs.pi`
+      # module, so it can't opt into the shared MCP servers via
+      # enableMcpIntegration. Configure MCP for it manually if needed.
+      agents.pi
 
-  # Shared MCP servers, defined once and fanned out to every client below
-  # via enableMcpIntegration. Each module transforms the generic schema
-  # into its native config format. Per-tool overrides remain possible
-  # through `programs.<tool>.mcpServers` / `.settings.mcp_servers`, which
-  # take precedence over these shared definitions.
-  programs.mcp = {
-    enable = true;
-    servers = {
-      # Skip a flaky test that asserts "Error" is not a substring of a
-      # randomly-picked /nix/store text file — fails when the picked
-      # file legitimately contains the word. Fixed upstream in
-      # utensils/mcp-nixos#154 but not yet in nixpkgs' 2.4.3 pin.
-      nixos.command = lib.getExe (pkgs.mcp-nixos.overridePythonAttrs (old: {
-        disabledTests = (old.disabledTests or [ ]) ++ [ "test_read_text_file" ];
-      }));
-      context7.command = lib.getExe pkgs.context7-mcp;
+      # ai: one-shot terminal prompt wrapping `claude -p` (reuses its login,
+      # MCP off, terse output). Lives here alongside the agent CLIs it shells out to.
+      self.packages.${pkgs.stdenv.hostPlatform.system}.ai
+    ];
+
+    # Shared MCP servers, defined once and fanned out to every client below
+    # via enableMcpIntegration. Each module transforms the generic schema
+    # into its native config format. Per-tool overrides remain possible
+    # through `programs.<tool>.mcpServers` / `.settings.mcp_servers`, which
+    # take precedence over these shared definitions.
+    programs.mcp = {
+      enable = true;
+      servers = {
+        # Skip a flaky test that asserts "Error" is not a substring of a
+        # randomly-picked /nix/store text file — fails when the picked
+        # file legitimately contains the word. Fixed upstream in
+        # utensils/mcp-nixos#154 but not yet in nixpkgs' 2.4.3 pin.
+        nixos.command = lib.getExe (pkgs.mcp-nixos.overridePythonAttrs (old: {
+          disabledTests = (old.disabledTests or [ ]) ++ [ "test_read_text_file" ];
+        }));
+        context7.command = lib.getExe pkgs.context7-mcp;
+      };
     };
-  };
 
-  programs.claude-code = {
-    enable = true;
-    package = agents.claude-code;
+    programs.claude-code = {
+      enable = true;
+      package = agents.claude-code;
 
-    enableMcpIntegration = true;
+      enableMcpIntegration = true;
 
-    # TODO: codex and antigravity-cli also expose a `skills` option with
-    # the same shape. Not sharing yet because skills often encode
-    # agent-specific assumptions (e.g. "use the Plan tool") that don't
-    # translate across CLIs. Revisit once there are real skills to
-    # classify — options for sharing later:
-    #   - Manual opt-in: list specific skill paths per client.
-    #   - Split dir: ./skills/shared/ vs ./skills/claude-only/.
-    skills = discoverSkills ./skills;
-  };
+      # Nix-managed settings. programs.claude-code.settings is used here for
+      # its type (JSON-serialisable attrset) and to keep the intent clear.
+      # The symlink it would normally generate is suppressed below — the
+      # activation script merges into a mutable file instead.
+      #
+      # Deliberately excluded (written by Claude Code's own /theme and /plugin
+      # UI commands — including them would silently revert user changes):
+      #   theme, enabledPlugins
+      settings = {
+        permissions.defaultMode = "auto";
+        skipAutoPermissionPrompt = true;
+        autoUpdatesChannel = "stable";
+        voice = {
+          enabled = true;
+          mode = "hold";
+        };
+        statusLine = {
+          type = "command";
+          command = ''input=$(cat); dir=$(echo "$input" | jq -r '.workspace.current_dir'); display="''${dir/$HOME/~}"; display=$(echo "$display" | awk -F'/' '{parts=0; for(i=1;i<=NF;i++) if($i!="") parts++; if(parts>3){p=""; c=0; for(i=NF;i>=1;i--) if($i!=""){p="/"$i p; if(++c==3)break}; print "..."p} else print $0}'); branch=$(git --no-optional-locks -C "$dir" symbolic-ref --short HEAD 2>/dev/null); dirty=""; git --no-optional-locks -C "$dir" status --porcelain 2>/dev/null | grep -q . && dirty="!"; model=$(echo "$input" | jq -r '.model.display_name'); used=$(echo "$input" | jq -r '.context_window.used_percentage // empty'); [ -n "$used" ] && printf "\033[1;33m[ctx:%.0f%%]\033[0m " "$used"; printf "\033[1;37m[%s]\033[0m " "$model"; printf "\033[1;36m[%s]\033[0m " "$display"; [ -n "$branch" ] && printf "\033[1;35m[%s%s]\033[0m" "$branch" "$dirty"'';
+        };
+      };
 
-  programs.codex = {
-    enable = true;
-    package = agents.codex;
+      # TODO: codex and antigravity-cli also expose a `skills` option with
+      # the same shape. Not sharing yet because skills often encode
+      # agent-specific assumptions (e.g. "use the Plan tool") that don't
+      # translate across CLIs. Revisit once there are real skills to
+      # classify — options for sharing later:
+      #   - Manual opt-in: list specific skill paths per client.
+      #   - Split dir: ./skills/shared/ vs ./skills/claude-only/.
+      skills = discoverSkills ./skills;
+    };
 
-    enableMcpIntegration = true;
-  };
+    # Suppress the read-only symlink that programs.claude-code.settings would
+    # normally generate — the activation script below writes a mutable copy
+    # instead, so Claude Code can write back to it (e.g. /theme, permissions).
+    home.file."${config.programs.claude-code.configDir}/settings.json".enable =
+      lib.mkForce false;
 
-  # gemini-cli was renamed upstream to antigravity-cli (Google rebrand).
-  programs.antigravity-cli = {
-    enable = true;
-    package = agents.antigravity-cli;
+    # Merge Nix-managed settings into ~/.claude/settings.json on each switch.
+    # nixSettingsFile is the combined shared + host-specific settings baked
+    # into the store at eval time. jq's recursive * operator applies it with
+    # Nix as the right operand — Nix wins on conflicts, keys absent from Nix
+    # (e.g. theme) survive untouched. Arrays/scalars are replaced wholesale.
+    home.activation.mergeClaudeSettings =
+      lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        settings="${config.home.homeDirectory}/.claude/settings.json"
 
-    enableMcpIntegration = true;
+        if [ -f "$settings" ] && [ ! -L "$settings" ]; then
+          overwritten=$(${lib.getExe pkgs.jq} -sr '
+            .[0] as $nix | .[1] as $live |
+            [ $nix | to_entries[] |
+              select($live[.key] != null and ($live[.key] | tojson) != (.value | tojson)) |
+              "~ \(.key)\n-  \($live[.key] | tojson)\n+  \(.value | tojson)"
+            ] | .[]
+          ' "${nixSettingsFile}" "$settings")
+
+          if [ -n "$overwritten" ]; then
+            echo "claude settings.json: Nix overwrote:"
+            echo "$overwritten"
+          fi
+
+          tmp="$settings.tmp"
+          ${lib.getExe pkgs.jq} -s '.[1] * .[0]' "${nixSettingsFile}" "$settings" > "$tmp" \
+            && $DRY_RUN_CMD mv "$tmp" "$settings" \
+            || rm -f "$tmp"
+        else
+          $DRY_RUN_CMD rm -f "$settings"
+          $DRY_RUN_CMD install -Dm 644 "${nixSettingsFile}" "$settings"
+        fi
+      '';
+
+    programs.codex = {
+      enable = true;
+      package = agents.codex;
+
+      enableMcpIntegration = true;
+    };
+
+    # gemini-cli was renamed upstream to antigravity-cli (Google rebrand).
+    programs.antigravity-cli = {
+      enable = true;
+      package = agents.antigravity-cli;
+
+      enableMcpIntegration = true;
+    };
   };
 }


### PR DESCRIPTION
Adds home.activation.mergeClaudeSettings to homes/john.pertoft/llm.nix. On each switch, jq deep-merges the Nix base into ~/.claude/settings.json using recursive * with Nix as the right operand — Nix wins on conflicts, imperative-only keys (theme, enabledPlugins, model) survive untouched. The file remains a plain writable file after activation, not a store symlink.

theme and enabledPlugins are deliberately absent from the Nix base: both are written by Claude Code's /theme and /plugin UI commands, and including them would silently revert user changes on every switch.